### PR TITLE
Añadir retorno de la desviación estándar a las funciones de MCMC

### DIFF
--- a/data/prob1.py
+++ b/data/prob1.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 from scipy.stats import bernoulli, uniform, beta
 
-data = pd.read_csv('prob1', header=0, delim_whitespace=True)
+data = pd.read_csv('./data/prob1', header=0, delim_whitespace=True)
 
 data = data.sort_values(by = ['d','a','theta'])
 

--- a/mcmc.py
+++ b/mcmc.py
@@ -59,7 +59,7 @@ def mcmc_adg(d_values, a_values, d_util, a_util, d_prob, a_prob,
         end = default_timer()
         theta_d = d_prob(d, a_opt[i], size=iters)
         psi_d[i] = d_util(d, theta_d).mean()
-        psi_d_std[i] = d_util(d, theta_d).std() / sqrt(inner_iters)
+        psi_d_std[i] = d_util(d, theta_d).std() / sqrt(iters)
         times[i] = end - start
 
     d_opt = d_values[psi_d.argmax()]

--- a/run_exp.py
+++ b/run_exp.py
@@ -126,10 +126,12 @@ if __name__ == '__main__':
             print('-' * 80)
             print('Iters: {}'.format(args.mcmc))
             with timer():
-                d_opt, a_opt, psi_d, psi_a, t = mcmc_adg(p.d_values, p.a_values,
-                                                         p.d_util, p.a_util,
-                                                         p.prob, p.prob,
-                                                         mcmc_iters=args.mcmc)
+                (d_opt, a_opt,
+                 psi_d, psi_d_std,
+                 psi_a, psi_a_std, t) = mcmc_adg(p.d_values, p.a_values,
+                                                 p.d_util, p.a_util,
+                                                 p.prob, p.prob,
+                                                 iters=args.mcmc)
                 # print('Elapsed time per attack: ', t)
 
             psi_d = pd.Series(psi_d, index=d_idx)
@@ -193,12 +195,13 @@ if __name__ == '__main__':
             print('-' * 80)
             print('Iters: {}'.format(args.mcmc))
             with timer():
-                d_opt, p_a, psi_da, psi_ad = mcmc_ara(p.d_values, p.a_values,
-                                                      p.d_util, p.a_util_f, p.prob,
-                                                      p.a_prob_f,
-                                                      mcmc_iters=args.mcmc,
-                                                      ara_iters=args.ara,
-                                                      n_jobs=args.njobs)
+                (d_opt, p_a, 
+                 psi_da, psi_da_std,
+                 psi_ad, psi_ad_std) = mcmc_ara(p.d_values, p.a_values,
+                                                p.d_util, p.a_util_f, p.prob,
+                                                p.a_prob_f, iters=args.mcmc,
+                                                ara_iters=args.ara,
+                                                n_jobs=args.njobs)
 
         elif args.alg == 'aps':
             print('APS')


### PR DESCRIPTION
Si todo OK habría que modificar `run_exp.py` para que imprima y/o guarde esa desviación. 

Otra opción es hacer los experimentos desde un notebook y llamar a las funciones directamente, guardando el retorno. En este caso habría que añadir este notebook al repo.